### PR TITLE
[Feat, Refact] AWS presignedUrl 발급 로직 추가 및 수정

### DIFF
--- a/src/main/java/com/whoa/whoaserver/bouquet/controller/BouquetImageController.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/controller/BouquetImageController.java
@@ -30,9 +30,9 @@ public class BouquetImageController {
 
     @PostMapping("/presigned_url")
     @Operation(summary = "이미지 등록 주소", description = "Header에 MEMBER_ID(key), 디바이스 등록 이후 반환 받은 id(value)로 요청하면 S3 이미지 저장을 위한 주소를 반환합니다.")
-    public ResponseEntity<PresignedUrlResponse> providePresignedUrl(@DeviceUser UserContext userContext) {
+    public ResponseEntity<PresignedUrlResponse> providePresignedUrl(@DeviceUser UserContext userContext, @RequestBody PresignedUrlRequest request) {
         
-        URL presignedUrl = bouquetImageService.createPresignedUrl(userContext);
+        URL presignedUrl = bouquetImageService.createPresignedUrl(userContext, request);
 
         return ResponseEntity.ok(PresignedUrlResponse.create(presignedUrl));
     }

--- a/src/main/java/com/whoa/whoaserver/bouquet/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/dto/request/PresignedUrlRequest.java
@@ -2,7 +2,8 @@ package com.whoa.whoaserver.bouquet.dto.request;
 
 public record PresignedUrlRequest(
     Long contentLength,
-    String extension
+    String extension,
+    String imgName
 ) {
     
 }


### PR DESCRIPTION
## 📒 개요
springboot + AWS S3 presignedUrl 발급 시 커스터마이징, 유효성 검증 로직 추가

## 📍 Issue 번호
close #23 

## 🛠️ 작업사항
- [x] postman에서 response body, 200 ok 모두 확인했습니다.
- [x] 기존 코드와 달리 이미지 이름을 유저가 지정할 수 있습니다.


