### PR TITLE
[Feat] 키워드별 꽃 조회에서 키워드 전체에 해당하는 꽃 조회 기능 추가

### DIFF
--- a/src/main/java/com/whoa/whoaserver/global/exception/ExceptionCode.java
+++ b/src/main/java/com/whoa/whoaserver/global/exception/ExceptionCode.java
@@ -11,6 +11,7 @@ public enum ExceptionCode {
     EXIST_MEMBER(HttpStatus.CONFLICT, "이미 존재하는 회원입니다."),
     INVALID_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
+    INVALID_FLOWER_AND_EXPRESSION(HttpStatus.NOT_FOUND, "꽃에 대응되는 꽃말이 없습니다."),
     NOT_REGISTER_BOUQUET(HttpStatus.NOT_FOUND, "등록되지 않은 꽃다발 주문서입니다."),
     NOT_MEMBER_BOUQUET(HttpStatus.CONFLICT, "해당 유저가 주문한 꽃다발이 아닙니다."),
 

--- a/src/main/java/com/whoa/whoaserver/keyword/service/FlowerKeywordService.java
+++ b/src/main/java/com/whoa/whoaserver/keyword/service/FlowerKeywordService.java
@@ -1,8 +1,10 @@
 package com.whoa.whoaserver.keyword.service;
 
 import com.whoa.whoaserver.flower.domain.Flower;
+import com.whoa.whoaserver.flower.repository.FlowerRepository;
 import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
 import com.whoa.whoaserver.flowerExpression.repository.FlowerExpressionRepository;
+import com.whoa.whoaserver.global.exception.WhoaException;
 import com.whoa.whoaserver.keyword.domain.Keyword;
 import com.whoa.whoaserver.keyword.dto.response.FlowerInfoByKeywordResponse;
 import com.whoa.whoaserver.keyword.repository.FlowerKeywordRepository;
@@ -13,31 +15,52 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.whoa.whoaserver.global.exception.ExceptionCode.*;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class FlowerKeywordService {
 
     private final FlowerKeywordRepository flowerKeywordRepository;
+    private final FlowerRepository flowerRepository;
     private final FlowerExpressionRepository flowerExpressionRepository;
 
     @Transactional
     public List<FlowerInfoByKeywordResponse> getFlowerInfoByKeyword(final Long keywordId) {
-        Keyword targetKeyword = flowerKeywordRepository.findByKeywordId(keywordId);
-        List<FlowerExpression> expressionCandidates = flowerExpressionRepository.findByFlowerLanguageContaining(targetKeyword.getKeywordName());
+        if (keywordId == 0) {
+            List<Flower> flowers = flowerRepository.findAll();
 
-        List<FlowerInfoByKeywordResponse> flowerInfoResponse = expressionCandidates.stream()
-                .map(flowerExpression -> {
-                    Flower flower = flowerExpression.getFlower();
-                    return new FlowerInfoByKeywordResponse(
-                            flower.getFlowerName(),
-                            flower.getFlowerImage(),
-                            List.of(flowerExpression.getFlowerLanguage())
-                    );
-                })
-                .collect(Collectors.toList());
+            List<FlowerInfoByKeywordResponse> flowerInfoResponse = flowers.stream()
+                    .map(flower -> {
+                        FlowerExpression flowerExpression = flowerExpressionRepository.findById(flower.getFlowerId())
+                                .orElseThrow(() -> new WhoaException(INVALID_FLOWER_AND_EXPRESSION));
+                        return new FlowerInfoByKeywordResponse(
+                                flower.getFlowerName(),
+                                flower.getFlowerImage(),
+                                List.of(flowerExpression.getFlowerLanguage())
+                        );
+                    })
+                    .collect(Collectors.toList());
+            return flowerInfoResponse;
+        } else {
 
-        return flowerInfoResponse;
+            Keyword targetKeyword = flowerKeywordRepository.findByKeywordId(keywordId);
+            List<FlowerExpression> expressionCandidates = flowerExpressionRepository.findByFlowerLanguageContaining(targetKeyword.getKeywordName());
+
+            List<FlowerInfoByKeywordResponse> flowerInfoResponse = expressionCandidates.stream()
+                    .map(flowerExpression -> {
+                        Flower flower = flowerExpression.getFlower();
+                        return new FlowerInfoByKeywordResponse(
+                                flower.getFlowerName(),
+                                flower.getFlowerImage(),
+                                List.of(flowerExpression.getFlowerLanguage())
+                        );
+                    })
+                    .collect(Collectors.toList());
+
+            return flowerInfoResponse;
+        }
 
     }
 }


### PR DESCRIPTION
## 📒 개요
- 기존 키워드별 꽃 조회에서 "전체"에 해당하는 것을 보려면 어떻게 해야하는지 질문에 대한 구현
- 프론트 구현 편리성을 고려해서 피그마 상에서 전체/사랑/믿음.. 이렇게 앱 상에서 bar가 순서대로 주어질 때 전체는 0, 그 이후부터는 1,2,.. 순서대로 요청 시 응답 반환

## 📍 Issue 번호
close #37 

## 🛠️ 작업사항
- [x] DB 상에 keyword, flower, flower_expression 엔티티에 임의로 값을 넣어서 postman 테스트 모두 완료 (아직 데이터 전달 받기 전)
- [x] 개별 키워드 조회와 전체 키워드 조회 공통 코드 리펙토링


## ❓ 추가 고려사항
리펙토링
