### PR TITLE
[CICD] application dev, prod 분리 및 submodules에서 git secrets 이용으로 pipleline 수정

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,15 +19,41 @@ jobs:
     steps:
     - name: Checkout-source code
       uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.PRIVATE_REPO_ACCESS_TOKEN }}
-        submodules: true
-        ref: main
+
     - name: JDK 17 설치
       uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
+
+    - name: Make application.yml
+      run: |
+        cd ./src/main/resources
+        
+        touch ./application.yml
+        touch ./application-dev.yml
+        touch ./application-credentials.yml
+        touch ./application-rds.yml
+        touch ./application-s3.yml
+        touch ./application-crawl.yml
+        
+        echo "$APPLICATION" > ./application.yml
+        echo "$APPLICATION_DEV" > ./application-dev.yml
+        echo "$APPLICATION_CREDENTIALS" > ./application-credentials.yml
+        echo "$APPLICATION_RDS" > ./application-rds.yml
+        echo "$APPLICATION_S3" > ./application-s3.yml
+        echo "$APPLICATION_CRAWL" > ./application-crawl.yml
+
+        env:
+          APPLICATION: ${{ secrets.APPLICATION }}
+          APPLICATION_DEV: ${{ secrets.APPLICATION_DEV }}
+          APPLICATION_CREDENTIALS: ${{ secrets.APPLICATION_CREDENTIALS }}
+          APPLICATION_RDS: ${{ secrets.APPLICATION_RDS }}
+          APPLICATION_S3: ${{ secrets.APPLICATION_S3 }}
+          APPLICATION_CRAWL: ${{ secrets.APPLICATION_CRAWL }}
+        shell: bash
+        
+
     - name: gradlew에 실행 권한 부여
       run: chmod +x ./gradlew
     - name: 프로젝트 빌드

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,14 +44,14 @@ jobs:
         echo "$APPLICATION_S3" > ./application-s3.yml
         echo "$APPLICATION_CRAWL" > ./application-crawl.yml
 
-        env:
-          APPLICATION: ${{ secrets.APPLICATION }}
-          APPLICATION_DEV: ${{ secrets.APPLICATION_DEV }}
-          APPLICATION_CREDENTIALS: ${{ secrets.APPLICATION_CREDENTIALS }}
-          APPLICATION_RDS: ${{ secrets.APPLICATION_RDS }}
-          APPLICATION_S3: ${{ secrets.APPLICATION_S3 }}
-          APPLICATION_CRAWL: ${{ secrets.APPLICATION_CRAWL }}
-        shell: bash
+      env:
+        APPLICATION: ${{ secrets.APPLICATION }}
+        APPLICATION_DEV: ${{ secrets.APPLICATION_DEV }}
+        APPLICATION_CREDENTIALS: ${{ secrets.APPLICATION_CREDENTIALS }}
+        APPLICATION_RDS: ${{ secrets.APPLICATION_RDS }}
+        APPLICATION_S3: ${{ secrets.APPLICATION_S3 }}
+        APPLICATION_CRAWL: ${{ secrets.APPLICATION_CRAWL }}
+      shell: bash
         
 
     - name: gradlew에 실행 권한 부여

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "cicdSecret"]
-	path = src/main/resources/secret
-	url = https://github.com/flower-project-2024/secret.git

--- a/build.gradle
+++ b/build.gradle
@@ -50,21 +50,10 @@ dependencies {
 	implementation 'org.jsoup:jsoup:1.14.3'
 
 	//mySQL
-	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
 
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
-}
-
-processResources.dependsOn('copySecret')
-
-tasks.register('copySecret', Copy) {
-    description = 'Copy submodules to project'
-
-    from('./src/main/resources/secret') {
-        include('*.yml')
-    }
-    into('src/main/resources')
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,22 @@
+spring:
+  config:
+    activate:
+      on-profile: "dev"
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+
+logging:
+  level:
+    org:
+      springframework:
+        web: DEBUG
+      hibernate:
+        orm:
+          jdbc:
+            bind: trace

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,21 @@
+spring:
+  config:
+    activate:
+      on-profile: "prod"
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+
+logging:
+  level:
+    org:
+      springframework: ERROR
+      hibernate:
+        orm:
+          jdbc:
+            bind: trace

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,15 @@
 spring:
   profiles:
-    include: credentials, rds, s3, crawl
+    group:
+      dev: "dev, rds, s3, crawl"
+      prod: "prod, rds, s3, crawl"
+    include:
+      - credentials
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
 
 logging:
   level:


### PR DESCRIPTION
## 📒 작업사항
- application.yml -> group을 dev와 prod로 분리하여 jpa 속성을 달리함
- cicd pipeline을 수정 -> application 관리 submodules 삭제

## 📍 Issue 번호
close #64 

