### PR TITLE
[Fix] POST 등록 시 bouquetName 예외 처리 정교화

### DIFF
--- a/src/main/java/com/whoa/whoaserver/bouquet/repository/BouquetRepository.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/repository/BouquetRepository.java
@@ -13,5 +13,4 @@ public interface BouquetRepository extends JpaRepository<Bouquet, Long>{
 
     Optional<Bouquet> findByMemberIdAndBouquetName(Long memberId, String bouquetName);
 
-    Optional<Bouquet> findByBouquetName(String bouquetName);
 }

--- a/src/main/java/com/whoa/whoaserver/bouquet/service/BouquetCustomizingService.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/service/BouquetCustomizingService.java
@@ -34,7 +34,7 @@ public class BouquetCustomizingService {
 
         Member member = getMemberByMemberId(memberId);
 
-        Optional<Bouquet> existingBouquetOptional = bouquetRepository.findByBouquetName(request.bouquetName());
+        Optional<Bouquet> existingBouquetOptional = bouquetRepository.findByMemberIdAndBouquetName(memberId, request.bouquetName());
 
         if (existingBouquetOptional.isPresent()) {
             throw new WhoaException(DUPLICATED_BOUQUET_NAME);

--- a/src/main/java/com/whoa/whoaserver/global/exception/ExceptionCode.java
+++ b/src/main/java/com/whoa/whoaserver/global/exception/ExceptionCode.java
@@ -14,7 +14,7 @@ public enum ExceptionCode {
     INVALID_FLOWER_AND_EXPRESSION(HttpStatus.NOT_FOUND, "꽃에 대응되는 꽃말이 없습니다."),
     NOT_REGISTER_BOUQUET(HttpStatus.NOT_FOUND, "등록되지 않은 꽃다발 주문서입니다."),
     NOT_MEMBER_BOUQUET(HttpStatus.CONFLICT, "해당 유저가 주문한 꽃다발이 아닙니다."),
-    DUPLICATED_BOUQUET_NAME(HttpStatus.CONFLICT, "이미 존재하는 꽃다발 주문서 이름입니다."),
+    DUPLICATED_BOUQUET_NAME(HttpStatus.CONFLICT, "해당 유저가 이미 동일한 꽃다발 주문서 이름으로 등록한 이력이 있습니다."),
 
     DUPLICATED_FILE_NAME(HttpStatus.CONFLICT, "이미 존재하는 파일 이름입니다."),
     IMAGE_SIZE_LIMIT_ERROR(HttpStatus.FORBIDDEN, "이미지의 크기가 기준을 초과합니다."),


### PR DESCRIPTION
## 📒 개요
bouquet 등록 시 이 테이블에 저장되는 bouquetName은 모두 고유했으나 동일한 유저는 서로 다른 bouquetName으로만 요청 가능하고 서로 다른 유저의 경우 bouquetName 상관 없도록 예외처리 수정

## 📍 Issue 번호
close #75 



