### PR TITLE
[Feat] 키워드 별 꽃 조회 꽃말에 따른 서로 다른 이미지 반환 및 발화 시기 고려

### DIFF
--- a/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetInfoDetailResponse.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetInfoDetailResponse.java
@@ -28,7 +28,7 @@ public record BouquetInfoDetailResponse(
 ) {
     public static BouquetInfoDetailResponse of(Bouquet bouquet, FlowerRepository flowerRepository) {
 
-        List<String> flowerTypes = FlowerUtils.parseFlowerType(bouquet.getFlowerType());
+        List<String> flowerTypes = FlowerUtils.parseFlowerEnumerationColumn(bouquet.getFlowerType());
         List<HashMap<String, String>> flowerInfoList = new ArrayList<>();
 
         for (String flowerType : flowerTypes) {

--- a/src/main/java/com/whoa/whoaserver/flower/repository/FlowerImageRepository.java
+++ b/src/main/java/com/whoa/whoaserver/flower/repository/FlowerImageRepository.java
@@ -1,0 +1,12 @@
+package com.whoa.whoaserver.flower.repository;
+
+import com.whoa.whoaserver.flower.domain.FlowerImage;
+import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FlowerImageRepository extends JpaRepository<FlowerImage, Long> {
+
+    Optional<FlowerImage> findByFlowerExpression(FlowerExpression flowerExpression);
+}

--- a/src/main/java/com/whoa/whoaserver/flower/utils/FlowerUtils.java
+++ b/src/main/java/com/whoa/whoaserver/flower/utils/FlowerUtils.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class FlowerUtils {
-    public static List<String> parseFlowerType(String flowerType) {
+    public static List<String> parseFlowerEnumerationColumn(String flowerType) {
 
         return Arrays.stream(flowerType.split(","))
                 .map(String::trim)

--- a/src/main/java/com/whoa/whoaserver/flowerExpression/domain/FlowerExpression.java
+++ b/src/main/java/com/whoa/whoaserver/flowerExpression/domain/FlowerExpression.java
@@ -2,6 +2,7 @@ package com.whoa.whoaserver.flowerExpression.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.whoa.whoaserver.flower.domain.Flower;
+import com.whoa.whoaserver.flower.domain.FlowerImage;
 import com.whoa.whoaserver.mapping.domain.FlowerExpressionKeyword;
 import jakarta.persistence.*;
 import lombok.*;
@@ -35,15 +36,20 @@ public class FlowerExpression {
     @OneToMany(mappedBy = "flowerExpression", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FlowerExpressionKeyword> flowerExpressionKeywords;
 
+    @OneToOne(mappedBy = "flowerExpression", fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
+    private FlowerImage flowerImage;
+
     @Builder(access = AccessLevel.PRIVATE)
     public FlowerExpression(
             final String flowerColor,
             final String flowerLanguage,
-            final Flower flower)
+            final Flower flower,
+            final FlowerImage flowerImage)
     {
         this.flowerColor = flowerColor;
         this.flowerLanguage = flowerLanguage;
         this.flower = flower;
+        this.flowerImage = flowerImage;
     }
 
 }

--- a/src/main/java/com/whoa/whoaserver/keyword/dto/response/FlowerInfoByKeywordResponse.java
+++ b/src/main/java/com/whoa/whoaserver/keyword/dto/response/FlowerInfoByKeywordResponse.java
@@ -1,5 +1,6 @@
 package com.whoa.whoaserver.keyword.dto.response;
 
+import com.whoa.whoaserver.flower.domain.FlowerImage;
 import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
 
 import java.util.List;
@@ -7,13 +8,17 @@ import java.util.List;
 public record FlowerInfoByKeywordResponse(
         String flowerName,
         String flowerLanguage,
+        String flowerImageUrl,
         List<String> flowerKeyword
 ) {
 
-    public static FlowerInfoByKeywordResponse fromFlowerExpressionAndKeyword(FlowerExpression flowerExpression, List<String> flowerKeyword) {
+    public static FlowerInfoByKeywordResponse fromFlowerExpressionAndKeyword(FlowerExpression flowerExpression, FlowerImage flowerImage, List<String> flowerKeyword) {
+        String imageUrl = (flowerImage != null) ? flowerImage.getImageUrl() : "";
+
         return new FlowerInfoByKeywordResponse(
                 flowerExpression.getFlower().getFlowerName(),
                 flowerExpression.getFlowerLanguage(),
+                imageUrl,
                 flowerKeyword
         );
     }

--- a/src/main/java/com/whoa/whoaserver/keyword/dto/response/FlowerInfoByKeywordResponse.java
+++ b/src/main/java/com/whoa/whoaserver/keyword/dto/response/FlowerInfoByKeywordResponse.java
@@ -6,14 +6,14 @@ import java.util.List;
 
 public record FlowerInfoByKeywordResponse(
         String flowerName,
-        String flowerImage,
+        String flowerLanguage,
         List<String> flowerKeyword
 ) {
 
     public static FlowerInfoByKeywordResponse fromFlowerExpressionAndKeyword(FlowerExpression flowerExpression, List<String> flowerKeyword) {
         return new FlowerInfoByKeywordResponse(
                 flowerExpression.getFlower().getFlowerName(),
-                flowerExpression.getFlower().getFlowerImages().get(0).getImageUrl(),
+                flowerExpression.getFlowerLanguage(),
                 flowerKeyword
         );
     }

--- a/src/main/java/com/whoa/whoaserver/keyword/service/FlowerKeywordService.java
+++ b/src/main/java/com/whoa/whoaserver/keyword/service/FlowerKeywordService.java
@@ -1,6 +1,9 @@
 package com.whoa.whoaserver.keyword.service;
 
+import com.whoa.whoaserver.flower.domain.FlowerImage;
+import com.whoa.whoaserver.flower.repository.FlowerImageRepository;
 import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
+import com.whoa.whoaserver.global.exception.WhoaException;
 import com.whoa.whoaserver.keyword.dto.response.FlowerInfoByKeywordResponse;
 import com.whoa.whoaserver.mapping.domain.FlowerExpressionKeyword;
 import com.whoa.whoaserver.mapping.repository.FlowerExpressionKeywordRepository;
@@ -11,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.whoa.whoaserver.global.exception.ExceptionCode.*;
+
 
 @Service
 @Transactional(readOnly = true)
@@ -19,6 +24,7 @@ public class FlowerKeywordService {
     private static final int TOTAL_FLOWER_INFORMATION = 0;
 
     private final FlowerExpressionKeywordRepository flowerExpressionKeywordRepository;
+    private final FlowerImageRepository flowerImageRepository;
 
     @Transactional
     public List<FlowerInfoByKeywordResponse> getFlowerInfoByKeyword(final Long keywordId) {
@@ -54,6 +60,9 @@ public class FlowerKeywordService {
                 .map(flowerExpressionKeyword -> flowerExpressionKeyword.getKeyword().getKeywordName())
                 .collect(Collectors.toUnmodifiableList());
 
-        return FlowerInfoByKeywordResponse.fromFlowerExpressionAndKeyword(flowerExpression, keywordNames);
+        FlowerImage flowerImage = flowerImageRepository.findByFlowerExpression(flowerExpression)
+                .orElse(null);
+
+        return FlowerInfoByKeywordResponse.fromFlowerExpressionAndKeyword(flowerExpression, flowerImage, keywordNames);
     }
 }

--- a/src/main/java/com/whoa/whoaserver/keyword/service/FlowerKeywordService.java
+++ b/src/main/java/com/whoa/whoaserver/keyword/service/FlowerKeywordService.java
@@ -15,8 +15,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
-
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -43,18 +41,22 @@ public class FlowerKeywordService {
     private List<FlowerExpression> getAllFlowerExpressions() {
         List<FlowerExpressionKeyword> mapping = flowerExpressionKeywordRepository.findAll();
         return mapping.stream()
-                .map(flowerExpressionKeyword -> flowerExpressionKeyword.getFlowerExpression())
-                .filter(flowerExpression -> FlowerUtils.parseFlowerEnumerationColumn(flowerExpression.getFlower().getComtemplationPeriod()).contains(String.valueOf(LocalDate.now().getMonthValue())))
+                .map(FlowerExpressionKeyword::getFlowerExpression)
+                .filter(this::isInContemplationPeriod)
                 .collect(Collectors.toUnmodifiableList());
     }
 
     private List<FlowerExpression> getExpressionsByKeyword(Long keywordId) {
         List<FlowerExpressionKeyword> mapping = flowerExpressionKeywordRepository.findAllByKeyword_KeywordId(keywordId);
-
         return mapping.stream()
                 .map(FlowerExpressionKeyword::getFlowerExpression)
-                .filter(flowerExpression -> FlowerUtils.parseFlowerEnumerationColumn(flowerExpression.getFlower().getComtemplationPeriod()).contains(String.valueOf(LocalDate.now().getMonthValue())))
+                .filter(this::isInContemplationPeriod)
                 .collect(Collectors.toUnmodifiableList());
+    }
+
+    private boolean isInContemplationPeriod(FlowerExpression flowerExpression) {
+        return FlowerUtils.parseFlowerEnumerationColumn(flowerExpression.getFlower().getComtemplationPeriod())
+                .contains(String.valueOf(LocalDate.now().getMonthValue()));
     }
 
     private FlowerInfoByKeywordResponse mapToResponse(FlowerExpression flowerExpression) {

--- a/src/main/java/com/whoa/whoaserver/keyword/service/FlowerKeywordService.java
+++ b/src/main/java/com/whoa/whoaserver/keyword/service/FlowerKeywordService.java
@@ -1,9 +1,6 @@
 package com.whoa.whoaserver.keyword.service;
 
-import com.whoa.whoaserver.flower.domain.Flower;
-import com.whoa.whoaserver.flower.repository.FlowerRepository;
 import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
-import com.whoa.whoaserver.global.exception.WhoaException;
 import com.whoa.whoaserver.keyword.dto.response.FlowerInfoByKeywordResponse;
 import com.whoa.whoaserver.mapping.domain.FlowerExpressionKeyword;
 import com.whoa.whoaserver.mapping.repository.FlowerExpressionKeywordRepository;
@@ -14,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.whoa.whoaserver.global.exception.ExceptionCode.INVALID_FLOWER_AND_EXPRESSION;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/com/whoa/whoaserver/keyword/service/FlowerKeywordService.java
+++ b/src/main/java/com/whoa/whoaserver/keyword/service/FlowerKeywordService.java
@@ -2,8 +2,8 @@ package com.whoa.whoaserver.keyword.service;
 
 import com.whoa.whoaserver.flower.domain.FlowerImage;
 import com.whoa.whoaserver.flower.repository.FlowerImageRepository;
+import com.whoa.whoaserver.flower.utils.FlowerUtils;
 import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
-import com.whoa.whoaserver.global.exception.WhoaException;
 import com.whoa.whoaserver.keyword.dto.response.FlowerInfoByKeywordResponse;
 import com.whoa.whoaserver.mapping.domain.FlowerExpressionKeyword;
 import com.whoa.whoaserver.mapping.repository.FlowerExpressionKeywordRepository;
@@ -11,10 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.whoa.whoaserver.global.exception.ExceptionCode.*;
 
 
 @Service
@@ -44,6 +44,7 @@ public class FlowerKeywordService {
         List<FlowerExpressionKeyword> mapping = flowerExpressionKeywordRepository.findAll();
         return mapping.stream()
                 .map(flowerExpressionKeyword -> flowerExpressionKeyword.getFlowerExpression())
+                .filter(flowerExpression -> FlowerUtils.parseFlowerEnumerationColumn(flowerExpression.getFlower().getComtemplationPeriod()).contains(String.valueOf(LocalDate.now().getMonthValue())))
                 .collect(Collectors.toUnmodifiableList());
     }
 
@@ -52,6 +53,7 @@ public class FlowerKeywordService {
 
         return mapping.stream()
                 .map(FlowerExpressionKeyword::getFlowerExpression)
+                .filter(flowerExpression -> FlowerUtils.parseFlowerEnumerationColumn(flowerExpression.getFlower().getComtemplationPeriod()).contains(String.valueOf(LocalDate.now().getMonthValue())))
                 .collect(Collectors.toUnmodifiableList());
     }
 


### PR DESCRIPTION
## 📍 Issue 번호
close #88 

## 🛠️ 작업사항
- [x] 기존 키워드별 꽃 조회 응답(꽃이름, 이미지, 키워드)에서 꽃말 추가
- [x] 꽃말 추가에 따라 꽃말에 따라 서로 다른 이미지(색깔) 경로 반환하도록 수정
- [x] 발화 시기까지 고려하여 요청 시기 기준이 발화 시기에 해당하는 것만 반환하도록 구현

200ok 및 발화 시기 비교까지 확인