### PR TITLE
[Feat] bouquet 단건 상세 조회 키워드에서 꽃말 반환으로 변경

### DIFF
--- a/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetInfoDetailResponse.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetInfoDetailResponse.java
@@ -6,7 +6,6 @@ import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record BouquetInfoDetailResponse(
         Long id,

--- a/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetInfoDetailResponse.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetInfoDetailResponse.java
@@ -18,7 +18,6 @@ public record BouquetInfoDetailResponse(
         String wrappingType,
         String priceRange,
         String requirement,
-        List<String> imagePaths,
         List<HashMap<String, String>> flowerInfoList // Flower Name, Flower Image, Flower language
 
 ) {
@@ -46,8 +45,6 @@ public record BouquetInfoDetailResponse(
                 bouquet.getWrappingType(),
                 bouquet.getPriceRange(),
                 bouquet.getRequirement(),
-                bouquet.getImages().stream().map(bouquetImage -> bouquetImage.getFileName())
-                        .collect(Collectors.toUnmodifiableList()),
                 flowerInfoList
         );
     }

--- a/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetInfoDetailResponse.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetInfoDetailResponse.java
@@ -1,11 +1,7 @@
 package com.whoa.whoaserver.bouquet.dto.response;
 
 import com.whoa.whoaserver.bouquet.domain.Bouquet;
-import com.whoa.whoaserver.flower.domain.Flower;
-import com.whoa.whoaserver.flower.repository.FlowerRepository;
-import com.whoa.whoaserver.flower.utils.FlowerUtils;
-import com.whoa.whoaserver.keyword.domain.Keyword;
-import com.whoa.whoaserver.keyword.repository.FlowerKeywordRepository;
+import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,31 +19,20 @@ public record BouquetInfoDetailResponse(
         String priceRange,
         String requirement,
         List<String> imagePaths,
-        List<HashMap<String, String>> flowerInfoList // Flower Name, Flower Image, Keyword Name
+        List<HashMap<String, String>> flowerInfoList // Flower Name, Flower Image, Flower language
 
 ) {
-    public static BouquetInfoDetailResponse of(Bouquet bouquet, FlowerRepository flowerRepository) {
+    public static BouquetInfoDetailResponse of(Bouquet bouquet, List<FlowerExpression> flowerExpressionList) {
 
-        List<String> flowerTypes = FlowerUtils.parseFlowerEnumerationColumn(bouquet.getFlowerType());
         List<HashMap<String, String>> flowerInfoList = new ArrayList<>();
 
-        for (String flowerType : flowerTypes) {
-            Flower flower = flowerRepository.findByFlowerName(flowerType);
+        for (FlowerExpression flowerExpression : flowerExpressionList) {
             HashMap<String, String> flowerInfo = new HashMap<>();
 
-            if (flower != null) {
-                flowerInfo.put("name", flower.getFlowerName());
-                flowerInfo.put("imageUrl", flower.getFlowerImages().get(0).getImageUrl());
-
-                List<String> keywordNames = flower.getFlowerExpressions().stream()
-                        .flatMap(flowerExpression -> flowerExpression.getFlowerExpressionKeywords().stream())
-                        .map(flowerExpressionKeyword -> flowerExpressionKeyword.getKeyword().getKeywordName())
-                        .collect(Collectors.toList());
-
-                if (keywordNames != null && !keywordNames.isEmpty()) {
-                    String keywordNamesString = String.join(", ", keywordNames);
-                    flowerInfo.put("flowerLanguage", keywordNamesString);
-                }
+            if (flowerExpression != null) {
+                flowerInfo.put("flowerName", flowerExpression.getFlower().getFlowerName());
+                flowerInfo.put("flowerImageUrl", flowerExpression.getFlowerImage().getImageUrl());
+                flowerInfo.put("flowerLanguage", flowerExpression.getFlowerLanguage());
             }
             flowerInfoList.add(flowerInfo);
         }

--- a/src/main/java/com/whoa/whoaserver/bouquet/service/BouquetCustomizingService.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/service/BouquetCustomizingService.java
@@ -2,7 +2,9 @@ package com.whoa.whoaserver.bouquet.service;
 
 import com.whoa.whoaserver.bouquet.dto.response.BouquetInfoDetailResponse;
 import com.whoa.whoaserver.bouquet.dto.response.BouquetOrderResponse;
-import com.whoa.whoaserver.flower.repository.FlowerRepository;
+import com.whoa.whoaserver.flower.utils.FlowerUtils;
+import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
+import com.whoa.whoaserver.flowerExpression.repository.FlowerExpressionRepository;
 import org.springframework.stereotype.Service;
 
 import com.whoa.whoaserver.bouquet.domain.Bouquet;
@@ -28,7 +30,7 @@ import static com.whoa.whoaserver.global.exception.ExceptionCode.*;
 public class BouquetCustomizingService {
     private final MemberRepository memberRepository;
     private final BouquetRepository bouquetRepository;
-    private final FlowerRepository flowerRepository;
+    private final FlowerExpressionRepository flowerExpressionRepository;
 
     public BouquetCustomizingResponse registerBouquet(BouquetCustomizingRequest request, Long memberId) {
 
@@ -124,7 +126,14 @@ public class BouquetCustomizingService {
         Bouquet bouquetToRead = bouquetRepository.findByMemberIdAndId(memberId, bouquetId)
                 .orElseThrow(() -> new WhoaException(NOT_REGISTER_BOUQUET));
 
-        return BouquetInfoDetailResponse.of(bouquetToRead, flowerRepository);
+        List<String> flowerExpressionStringIdsList = FlowerUtils.parseFlowerEnumerationColumn(bouquetToRead.getFlowerType());
+        List<Long> flowerExpressionLongIdsList =flowerExpressionStringIdsList.stream()
+                .map( id -> Long.parseLong(id))
+                .collect(Collectors.toUnmodifiableList());
+        List<FlowerExpression> flowerExpressionList = flowerExpressionLongIdsList.stream()
+                .map(id -> flowerExpressionRepository.findByFlowerExpressionId(id))
+                .collect(Collectors.toUnmodifiableList());
+        return BouquetInfoDetailResponse.of(bouquetToRead, flowerExpressionList);
     }
 
     private Member getMemberByMemberId(Long memberId) {

--- a/src/main/java/com/whoa/whoaserver/flowerExpression/repository/FlowerExpressionRepository.java
+++ b/src/main/java/com/whoa/whoaserver/flowerExpression/repository/FlowerExpressionRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface FlowerExpressionRepository extends JpaRepository<FlowerExpression, Long> {
     List<FlowerExpression> findByFlowerLanguageContaining(String flowerKeyword);
+    FlowerExpression findByFlowerExpressionId(Long flowerExpressionid);
 }

--- a/src/main/java/com/whoa/whoaserver/keyword/dto/response/FlowerInfoByKeywordResponse.java
+++ b/src/main/java/com/whoa/whoaserver/keyword/dto/response/FlowerInfoByKeywordResponse.java
@@ -6,6 +6,7 @@ import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
 import java.util.List;
 
 public record FlowerInfoByKeywordResponse(
+        Long id,
         String flowerName,
         String flowerLanguage,
         String flowerImageUrl,
@@ -16,6 +17,7 @@ public record FlowerInfoByKeywordResponse(
         String imageUrl = (flowerImage != null) ? flowerImage.getImageUrl() : "";
 
         return new FlowerInfoByKeywordResponse(
+                flowerExpression.getFlowerExpressionId(),
                 flowerExpression.getFlower().getFlowerName(),
                 flowerExpression.getFlowerLanguage(),
                 imageUrl,


### PR DESCRIPTION
## 📒 개요
(2024.06.22 회의) 피그마 상 변경 내역 반영

## 📍 Issue 번호
close #88 

## 🛠️ 작업사항
- [x] 키워드별 꽃 조회에 id 반환 값 추가
- [x] 해당 id로 bouquet create (flowerType)
- [x] bouquet 상세 조회 시 flowerInfoList hastMap 응답 내역 변경


