### PR TITLE
[Fix] 꽃 상세조회/오늘의 꽃 추천 API 수정

### DIFF
--- a/src/main/java/com/whoa/whoaserver/flower/dto/FlowerPostResponseDto.java
+++ b/src/main/java/com/whoa/whoaserver/flower/dto/FlowerPostResponseDto.java
@@ -1,40 +1,36 @@
 package com.whoa.whoaserver.flower.dto;
 
 import com.whoa.whoaserver.flower.domain.Flower;
-import com.whoa.whoaserver.flower.domain.FlowerImage;
 import com.whoa.whoaserver.flowerExpression.dto.FlowerExpressionResponseDto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Collectors;
 
 import static lombok.AccessLevel.PRIVATE;
 
 @Getter
 @RequiredArgsConstructor(access=PRIVATE)
-public class FlowerResponseDto {
+public class FlowerPostResponseDto {
     private final Long flowerId;
     private final String flowerName;
     private final String flowerDescription;
     private final String flowerOneLineDescription;
-    private final List<String> flowerImages;
     private final String birthFlower;
     private final String managementMethod;
     private final String storageMethod;
     private final List<FlowerExpressionResponseDto> flowerExpressions;
 
-    public static FlowerResponseDto of(Flower flower, List<String> flowerImages) {
+    public static FlowerPostResponseDto of(Flower flower) {
         List<FlowerExpressionResponseDto> expressionResponseDtos = flower.getFlowerExpressions().stream()
                 .map(FlowerExpressionResponseDto::of)
                 .collect(Collectors.toList());
-        return new FlowerResponseDto(
+        return new FlowerPostResponseDto(
                 flower.getFlowerId(),
                 flower.getFlowerName(),
                 flower.getFlowerDescription(),
                 flower.getFlowerOneLineDescription(),
-                flowerImages,
                 flower.getBirthFlower(),
                 flower.getManagementMethod(),
                 flower.getStorageMethod(),
@@ -42,5 +38,3 @@ public class FlowerResponseDto {
         );
     }
 }
-
-

--- a/src/main/java/com/whoa/whoaserver/flower/dto/FlowerRecommendResponseDto.java
+++ b/src/main/java/com/whoa/whoaserver/flower/dto/FlowerRecommendResponseDto.java
@@ -1,6 +1,7 @@
 package com.whoa.whoaserver.flower.dto;
 
 import com.whoa.whoaserver.flower.domain.Flower;
+import com.whoa.whoaserver.flower.domain.FlowerImage;
 import com.whoa.whoaserver.flowerExpression.dto.FlowerExpressionResponseDto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -23,11 +24,17 @@ public class FlowerRecommendResponseDto {
         List<FlowerExpressionResponseDto> expressionResponseDtos = flower.getFlowerExpressions().stream()
                 .map(FlowerExpressionResponseDto::of)
                 .collect(Collectors.toList());
+        String flowerImageUrl = null;
+        for (FlowerImage flowerImage : flower.getFlowerImages()) {
+            flowerImageUrl = flowerImage.getImageUrl();
+            if (flowerImageUrl != null)
+                break;
+        }
         return new FlowerRecommendResponseDto(
                 flower.getFlowerId(),
                 flower.getFlowerName(),
                 flower.getFlowerOneLineDescription(),
-                flower.getFlowerImages().get(0).getImageUrl(),
+                flowerImageUrl,
                 expressionResponseDtos
         );
     }

--- a/src/main/java/com/whoa/whoaserver/flower/repository/FlowerRepository.java
+++ b/src/main/java/com/whoa/whoaserver/flower/repository/FlowerRepository.java
@@ -13,7 +13,10 @@ public interface FlowerRepository extends JpaRepository<Flower, Long> {
 
     Flower findByFlowerName(String flowerName);
     
-    Flower findFlowerByRecommendDate(String recommendDate);
+    Optional<Flower> findFlowerByRecommendDate(String recommendDate);
+
+    @Query("SELECT f FROM Flower f ORDER BY RAND() LIMIT 1")
+    Flower findRandomFlower();
 
     @Query("SELECT f.flowerDescription FROM Flower f WHERE f.flowerName = :flowerName")
     Optional<String> findFlowerDescriptionByFlowerName(@Param("flowerName") String flowerName);

--- a/src/main/java/com/whoa/whoaserver/flower/service/FlowerService.java
+++ b/src/main/java/com/whoa/whoaserver/flower/service/FlowerService.java
@@ -15,9 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -57,7 +55,13 @@ public class FlowerService {
     @Transactional
     public FlowerRecommendResponseDto getRecommendFlower(final int month, final int date){
         String recommendDate = month + "/" + date;
-        Flower recommendFlower = flowerRepository.findFlowerByRecommendDate(recommendDate);
+        Flower recommendFlower = null;
+        Optional<Flower> recommendAcceptFlower = flowerRepository.findFlowerByRecommendDate(recommendDate);
+        if (recommendAcceptFlower.isPresent())
+            recommendFlower = recommendAcceptFlower.get();
+        else {
+            recommendFlower = flowerRepository.findRandomFlower();
+        }
         return FlowerRecommendResponseDto.of(recommendFlower);
     }
 

--- a/src/main/java/com/whoa/whoaserver/flowerExpression/repository/FlowerExpressionRepository.java
+++ b/src/main/java/com/whoa/whoaserver/flowerExpression/repository/FlowerExpressionRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface FlowerExpressionRepository extends JpaRepository<FlowerExpression, Long> {
     List<FlowerExpression> findByFlowerLanguageContaining(String flowerKeyword);
     FlowerExpression findByFlowerExpressionId(Long flowerExpressionid);
+
+    List<FlowerExpression> findByFlowerFlowerId(Long flowerId);
 }


### PR DESCRIPTION
## 📒 개요
- 꽃 상세조회/오늘의 꽃 추천 API 수정

## 📍 Issue 번호
#96 

## 🛠️ 작업사항
- [x] 꽃 상세 조회 시, 변경된 entity에 맞게 image URL이 전달되도록 로직 수정
- [x] 오늘의 꽃 추천 시, 랜덤 로직 추가
- [x] 오늘의 꽃 추천 시, 변경된 entity에 맞게 image URL이 전달되도록 로직 수정 

## ❓ 추가 고려사항

