### PR TITLE
[Fix] 꽃말에 따른 꽃 이미지 저장 API Hibernate 500 error 해결

### DIFF
--- a/src/main/java/com/whoa/whoaserver/flower/controller/FlowerController.java
+++ b/src/main/java/com/whoa/whoaserver/flower/controller/FlowerController.java
@@ -1,5 +1,6 @@
 package com.whoa.whoaserver.flower.controller;
 
+import com.whoa.whoaserver.flower.domain.Flower;
 import com.whoa.whoaserver.flower.dto.FlowerRequestDto;
 import com.whoa.whoaserver.flower.service.FlowerService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,9 +24,9 @@ public class FlowerController {
     private final FlowerService flowerService;
 
     @PostMapping()
-    @Operation(summary = "꽃 사진 등록", description = "데이터 저장용 API입니다.")
-    public ResponseEntity<?> postFlower(List<MultipartFile> flowerImages, @PathVariable final Long flowerId) throws IOException {
-        return ResponseEntity.ok().body(flowerService.postFlower(flowerImages, flowerId));
+    @Operation(summary = "꽃 등록", description = "데이터 저장용 API입니다.")
+    public ResponseEntity<?> postFlower(Flower flower) {
+        return ResponseEntity.ok().body(flowerService.postFlower(flower));
     }
 
     @GetMapping("detail/{flowerId}")

--- a/src/main/java/com/whoa/whoaserver/flower/domain/FlowerImage.java
+++ b/src/main/java/com/whoa/whoaserver/flower/domain/FlowerImage.java
@@ -29,7 +29,8 @@ public class FlowerImage {
     @JoinColumn(name = "flower_expression_id")
     private FlowerExpression flowerExpression;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    //@Builder(access = AccessLevel.PRIVATE)
+    @Builder
     public FlowerImage(
             final Flower flower,
             final String imageUrl,

--- a/src/main/java/com/whoa/whoaserver/flower/domain/FlowerImage.java
+++ b/src/main/java/com/whoa/whoaserver/flower/domain/FlowerImage.java
@@ -10,7 +10,6 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
-@DynamicInsert
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
 public class FlowerImage {

--- a/src/main/java/com/whoa/whoaserver/flower/service/FlowerService.java
+++ b/src/main/java/com/whoa/whoaserver/flower/service/FlowerService.java
@@ -24,15 +24,8 @@ public class FlowerService {
     final S3Uploader s3Uploader;
 
     @Transactional
-    public FlowerResponseDto postFlower(final List<MultipartFile> flowerImages, final Long flowerId) throws IOException {
-        Flower flower = flowerRepository.findByFlowerId(flowerId);
-        List<FlowerImage> storedFlowerImages = new ArrayList<>();
-        for (MultipartFile flowerImage : flowerImages) {
-            String storedFileName = s3Uploader.saveFileExceptUser(flowerImage, "flower");
-            FlowerImage flowerImageEntity = FlowerImage.create(storedFileName, flower);
-            storedFlowerImages.add(flowerImageEntity);
-        }
-        flower.getFlowerImages().addAll(storedFlowerImages);
+    public FlowerResponseDto postFlower(final Flower flower){
+        flowerRepository.save(flower);
         return FlowerResponseDto.of(flower);
     }
 

--- a/src/main/java/com/whoa/whoaserver/flowerExpression/controller/FlowerExpressionController.java
+++ b/src/main/java/com/whoa/whoaserver/flowerExpression/controller/FlowerExpressionController.java
@@ -24,7 +24,7 @@ public class FlowerExpressionController {
 
     @PostMapping("{flowerId}")
     @Operation(summary = "꽃말과 사진 등록", description = "데이터 저장용 API입니다.")
-    public ResponseEntity<?> postFlower(@RequestParam("Image") MultipartFile Image, @PathVariable Long flowerId, FlowerExpression flowerExpression) throws IOException {
+    public ResponseEntity<?> postFlower(@RequestPart("Image") MultipartFile Image, @PathVariable Long flowerId, FlowerExpression flowerExpression) throws IOException {
         return ResponseEntity.ok().body(flowerExpressionService.postFlowerExpressions(Image, flowerId, flowerExpression));
     }
 

--- a/src/main/java/com/whoa/whoaserver/flowerExpression/controller/FlowerExpressionController.java
+++ b/src/main/java/com/whoa/whoaserver/flowerExpression/controller/FlowerExpressionController.java
@@ -1,0 +1,31 @@
+package com.whoa.whoaserver.flowerExpression.controller;
+
+import com.whoa.whoaserver.flower.service.FlowerService;
+import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
+import com.whoa.whoaserver.flowerExpression.service.FlowerExpressionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@Tag(name = "Flower Detail&Recommend", description = "PathVariable 필요")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/flowerExpressions")
+public class FlowerExpressionController {
+    @Autowired
+    private final FlowerExpressionService flowerExpressionService;
+
+    @PostMapping("{flowerId}")
+    @Operation(summary = "꽃말과 사진 등록", description = "데이터 저장용 API입니다.")
+    public ResponseEntity<?> postFlower(@RequestParam("Image") MultipartFile Image, @PathVariable Long flowerId, FlowerExpression flowerExpression) throws IOException {
+        return ResponseEntity.ok().body(flowerExpressionService.postFlowerExpressions(Image, flowerId, flowerExpression));
+    }
+
+}

--- a/src/main/java/com/whoa/whoaserver/flowerExpression/domain/FlowerExpression.java
+++ b/src/main/java/com/whoa/whoaserver/flowerExpression/domain/FlowerExpression.java
@@ -15,6 +15,7 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@Setter
 @DynamicInsert
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)

--- a/src/main/java/com/whoa/whoaserver/flowerExpression/service/FlowerExpressionService.java
+++ b/src/main/java/com/whoa/whoaserver/flowerExpression/service/FlowerExpressionService.java
@@ -1,0 +1,47 @@
+package com.whoa.whoaserver.flowerExpression.service;
+
+import com.whoa.whoaserver.flower.domain.Flower;
+import com.whoa.whoaserver.flower.domain.FlowerImage;
+import com.whoa.whoaserver.flower.repository.FlowerImageRepository;
+import com.whoa.whoaserver.flower.repository.FlowerRepository;
+import com.whoa.whoaserver.flower.service.S3Uploader;
+import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
+import com.whoa.whoaserver.flowerExpression.dto.FlowerExpressionResponseDto;
+import com.whoa.whoaserver.flowerExpression.repository.FlowerExpressionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class FlowerExpressionService {
+
+    final FlowerExpressionRepository flowerExpressionRepository;
+    final FlowerImageRepository flowerImageRepository;
+    final FlowerRepository flowerRepository;
+    final S3Uploader s3Uploader;
+
+    @Transactional
+    public FlowerExpressionResponseDto postFlowerExpressions(MultipartFile flowerImageUrl, Long flowerId, FlowerExpression flowerExpression) throws IOException {
+        Flower flower = flowerRepository.findByFlowerId(flowerId);
+        System.out.println("1여기");
+        flowerExpression.setFlower(flower);
+        System.out.println("2여기");
+        FlowerExpression flowerExpression1 = flowerExpressionRepository.save(flowerExpression);
+        System.out.println("3여기");
+        String storedFileName = s3Uploader.saveFileExceptUser(flowerImageUrl, "flower");
+        System.out.println("4여기");
+        FlowerImage flowerImage = FlowerImage.builder()
+                .flower(flower)
+                .imageUrl(storedFileName)
+                .flowerExpression(flowerExpression1)
+                .build();
+        System.out.println("5여기");
+        flowerImageRepository.save(flowerImage);
+        System.out.println("6여기");
+        return FlowerExpressionResponseDto.of(flowerExpression1);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
       prod: "prod, rds, s3, crawl"
     include:
       - credentials
+  servlet:
+    multipart:
+      maxFileSize: 30000000000KB # 파일 하나의 최대 크기
+      maxRequestSize: 60000000000KB  # 한 번에 최대 업로드 가능 용량
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 📒 작업 내역 설명
꽃에 대한 정보를 저장하는 API는 200 OK가 잘 떴으나 FlowerExpressionController에서 꽃말과 그에 따른 이미지를 한꺼번에 저장하는 로직에서 `The database returned no natively generated identity value`라는 Hibernate 예외 에러 발생

- pathVariable로 받는 flowerId로 flower 객체에 대해 flowerExpression 객체 만들어 저장 -> 구현하신 s3uploader로 꽃말에 대응되는 이미지 url 생성하여 flowerImage 객체 생성까지는 되지만 flowerImage가 save가 안되는 문제 해결


## 📍 Issue 번호
#98 

## 🛠️ 참고 사항
배포용 X



