### PR TITLE
Refact: bouquet 등록과 다중 이미지 업로드를 하나의 엔드포인트로 통합

### DIFF
--- a/src/main/java/com/whoa/whoaserver/bouquet/controller/BouquetCustomizingController.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/controller/BouquetCustomizingController.java
@@ -1,6 +1,10 @@
 package com.whoa.whoaserver.bouquet.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whoa.whoaserver.bouquet.dto.response.BouquetInfoDetailResponse;
+import com.whoa.whoaserver.global.exception.WhoaException;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +19,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static com.whoa.whoaserver.global.exception.ExceptionCode.*;
 
 @Tag(name = "Bouquet Customizing", description = "Header에 MEMBER_ID(key), 디바이스 등록 이후 반환 받은 id(value)로 요청해주세요.")
 @RestController
@@ -23,13 +32,25 @@ import lombok.RequiredArgsConstructor;
 public class BouquetCustomizingController {
 
     private final BouquetCustomizingService bouquetCustomizingService;
+	private final ObjectMapper objectMapper;
 
-    @PostMapping("/customizing")
+    @PostMapping(value ="/customizing", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "꽃다발 제작", description = "꽃다발 주문을 등록합니다.")
-    public ResponseEntity<BouquetCustomizingResponse> registerBouquet(@DeviceUser UserContext userContext, @Valid @RequestBody BouquetCustomizingRequest request) { 
-        Long memberId = userContext.id();
-        BouquetCustomizingResponse response = bouquetCustomizingService.registerBouquet(request, memberId);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<BouquetCustomizingResponse> registerBouquet(@DeviceUser UserContext userContext,
+																	  @Valid @RequestPart("request") String bouquetRequest,
+																	  @RequestPart("imgUrl") List<MultipartFile> multipartFiles) {
+
+		try {
+			Long memberId = userContext.id();
+			BouquetCustomizingRequest request = objectMapper.readValue(bouquetRequest, BouquetCustomizingRequest.class);
+			BouquetCustomizingResponse response = bouquetCustomizingService.registerBouquet(request, memberId, multipartFiles);
+			return ResponseEntity.ok(response);
+		} catch (JsonProcessingException e) {
+			throw new WhoaException(INVALID_BOUQUET_REQUEST_JSON_FORMAT);
+		} catch (Exception e) {
+			throw new WhoaException(IMAGE_UPLOAD_ERROR);
+		}
+
     }
 
     @PutMapping("/customizing/{bouquetId}")

--- a/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetCustomizingResponse.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetCustomizingResponse.java
@@ -2,10 +2,13 @@ package com.whoa.whoaserver.bouquet.dto.response;
 
 import com.whoa.whoaserver.bouquet.domain.Bouquet;
 
+import java.util.List;
+
 public record BouquetCustomizingResponse(
-    Long bouquetId
+    Long bouquetId,
+	List<String> imgList
 ) {
-    public static BouquetCustomizingResponse of(Bouquet bouquet) {
-        return new BouquetCustomizingResponse(bouquet.getId());
+    public static BouquetCustomizingResponse of(Bouquet bouquet, List<String> imgList) {
+        return new BouquetCustomizingResponse(bouquet.getId(), imgList);
     }
  }

--- a/src/main/java/com/whoa/whoaserver/global/exception/ExceptionCode.java
+++ b/src/main/java/com/whoa/whoaserver/global/exception/ExceptionCode.java
@@ -22,6 +22,7 @@ public enum ExceptionCode {
     NULL_INPUT_CONTENT(HttpStatus.CONFLICT, "이미지 파일이 null로 인식됩니다."),
     IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
     INVALID_BOUQUET_ID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "이미지 업로드 시 bouquetId를 key로 하는 value가 json(bouquet_id : Long) 형식이어야 합니다."),
+	INVALID_BOUQUET_REQUEST_JSON_FORMAT(HttpStatus.BAD_REQUEST, "이미지 업로드 시 request를 key로 하는 value가 json string 형식이어야 합니다."),
     MISMATCH_MEMBER_AND_IMAGE(HttpStatus.BAD_REQUEST, "해당 유저가 수정하려는 이미지를 업로드한 내역이 없습니다. 유저가 업로드한 이미지 아이디로 요청해주세요."),
     NOT_REGISTER_BOUQUET_IMAGE(HttpStatus.NOT_FOUND, "업로드 된 적이 없는 이미지입니다."),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "올바른 S3 이미지 경로 URL 형식이 아닙니다.");


### PR DESCRIPTION
## 📒 개요
아래와 같이 요청 시 200 ok 반환
![스크린샷 2024-08-21 132440](https://github.com/user-attachments/assets/b828554a-769e-4e50-a65c-87d663a6716f)

## 📍 Issue 번호
close #120 

## ❓ 추가 고려사항
bouquet 수정 시에도 이미지와 통합하여 하나의 엔드포인트로 관리하는 API 개발 필요
