### PR TITLE
Refact: bouquet 수정과 다중 이미지 수정을 하나의 엔드포인트로 통합

### DIFF
--- a/src/main/java/com/whoa/whoaserver/bouquet/controller/BouquetCustomizingController.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/controller/BouquetCustomizingController.java
@@ -35,7 +35,7 @@ public class BouquetCustomizingController {
 	private final ObjectMapper objectMapper;
 
     @PostMapping(value ="/customizing", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "꽃다발 제작", description = "꽃다발 주문을 등록합니다.")
+    @Operation(summary = "꽃다발 제작", description = "꽃다발 주문과 이미지를 등록합니다.")
     public ResponseEntity<BouquetCustomizingResponse> registerBouquet(@DeviceUser UserContext userContext,
 																	  @Valid @RequestPart("request") String bouquetRequest,
 																	  @RequestPart("imgUrl") List<MultipartFile> multipartFiles) {
@@ -54,11 +54,22 @@ public class BouquetCustomizingController {
     }
 
     @PutMapping("/customizing/{bouquetId}")
-    @Operation(summary = "꽃다발 수정", description = "유저의 꽃다발 주문서를 수정합니다.")
-    public ResponseEntity<BouquetCustomizingResponse> updateBouquet(@DeviceUser UserContext userContext, @Valid @RequestBody BouquetCustomizingRequest request, @PathVariable("bouquetId") final Long bouquetId) {
-        Long memberId = userContext.id();
-        BouquetCustomizingResponse response = bouquetCustomizingService.updateBouquet(request, memberId, bouquetId);
-        return ResponseEntity.ok(response);
+    @Operation(summary = "꽃다발 수정", description = "유저의 꽃다발 주문서와 이미지를 수정합니다.")
+    public ResponseEntity<BouquetCustomizingResponse> updateBouquet(@DeviceUser UserContext userContext,
+																	@Valid @RequestPart("request") String bouquetRequest,
+																	@RequestPart("imgUrl") List<MultipartFile> multipartFiles,
+																	@PathVariable("bouquetId") final Long bouquetId) {
+
+		try {
+			Long memberId = userContext.id();
+			BouquetCustomizingRequest request = objectMapper.readValue(bouquetRequest, BouquetCustomizingRequest.class);
+			BouquetCustomizingResponse response = bouquetCustomizingService.updateBouquet(request, memberId, bouquetId, multipartFiles);
+			return ResponseEntity.ok(response);
+		} catch (JsonProcessingException e) {
+			throw new WhoaException(INVALID_BOUQUET_REQUEST_JSON_FORMAT);
+		} catch (Exception e) {
+			throw new WhoaException(IMAGE_UPLOAD_ERROR);
+		}
     }
 
     @DeleteMapping("/{bouquetId}")

--- a/src/main/java/com/whoa/whoaserver/bouquet/repository/BouquetImageRepository.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/repository/BouquetImageRepository.java
@@ -1,11 +1,16 @@
 package com.whoa.whoaserver.bouquet.repository;
 
+import com.whoa.whoaserver.bouquet.domain.Bouquet;
 import com.whoa.whoaserver.bouquet.domain.BouquetImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.*;
 
 @Repository
 public interface BouquetImageRepository extends JpaRepository<BouquetImage, Long> {
 
     boolean existsByFileName(String fileName);
+
+	List<BouquetImage> findAllByBouquet(Bouquet bouquet);
 }

--- a/src/main/java/com/whoa/whoaserver/bouquet/service/BouquetCustomizingService.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/service/BouquetCustomizingService.java
@@ -86,7 +86,7 @@ public class BouquetCustomizingService {
 		}
 	}
 
-    public BouquetCustomizingResponse updateBouquet(BouquetCustomizingRequest request, Long memberId, Long bouquetId) {
+    public BouquetCustomizingResponse updateBouquet(BouquetCustomizingRequest request, Long memberId, Long bouquetId, List<MultipartFile> multipartFiles) {
         Member member = getMemberByMemberId(memberId);
 
         Bouquet existingBouquet = getBouquetByMemberIdAndBouquetId(memberId, bouquetId);
@@ -109,6 +109,12 @@ public class BouquetCustomizingService {
         );
 
         bouquetRepository.save(existingBouquet);
+
+		List<BouquetImage> existingBouquetImages = bouquetImageRepository.findAllByBouquet(existingBouquet);
+		bouquetImageRepository.deleteAll(existingBouquetImages);
+
+		List<String> imgPaths = s3Config.upload(multipartFiles);
+		saveMultipleFilesUrlWithBouquetAtOnce(memberId, imgPaths, existingBouquet.getId());
 
 		List<String> imgUrl = existingBouquet.getImages().stream().map(BouquetImage::getFileName)
 			.collect(Collectors.toUnmodifiableList());


### PR DESCRIPTION
## 📒 개요
POST bouquet 등록과 마찬가지 방식으로 요청 + bouquetId PathVariable 필요
![스크린샷 2024-08-22 160308](https://github.com/user-attachments/assets/7e1f5267-0886-4bad-98b7-4178758e59ae)


## 📍 Issue 번호
close #122 

## ❓ 추가 고려사항
POST, PUT API 리펙토링 필요
