### PR TITLE
[Refact] 상태에 따른 bouquet 전체 조회 프론트에서 필터링하도록 구현

### DIFF
--- a/src/main/java/com/whoa/whoaserver/bouquet/controller/BouquetCustomizingControllerV2.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/controller/BouquetCustomizingControllerV2.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whoa.whoaserver.bouquet.dto.request.BouquetCustomizingRequest;
 import com.whoa.whoaserver.bouquet.dto.response.BouquetCustomizingResponseV2;
-import com.whoa.whoaserver.bouquet.dto.response.BouquetOrderResponse;
+import com.whoa.whoaserver.bouquet.dto.response.BouquetOrderResponseV2;
 import com.whoa.whoaserver.bouquet.service.BouquetCustomizingServiceV2;
 import com.whoa.whoaserver.global.annotation.DeviceUser;
 import com.whoa.whoaserver.global.dto.UserContext;
@@ -86,13 +86,12 @@ public class BouquetCustomizingControllerV2 {
 	}
 
 	@GetMapping("/all/status")
-	@Operation(summary = "꽃다발 제작 완료 여부에 따른 전체 조회", description = "마이 페이지에서 저장된 요구서와 제작 완료 항목을 분리하여 반환합니다.")
-	public ResponseEntity<Map<String, List<BouquetOrderResponse>>> getAllBouquetsByBouquetStatus(
+	@Operation(summary = "꽃다발 제작 완료 여부에 따른 전체 조회", description = "마이 페이지에서 상태를 추가하여 반환합니다.")
+	public ResponseEntity<List<BouquetOrderResponseV2>> getAllBouquetsWithStatus(
 		@DeviceUser UserContext userContext
 	) {
 		Long memberId = userContext.id();
-		Map<String, List<BouquetOrderResponse>> response = bouquetCustomizingService.getAllBouquetsByBouquetStatus(memberId);
-		return ResponseEntity.ok(response);
+		return ResponseEntity.ok().body(bouquetCustomizingService.getAllBouquetsWithStatus(memberId));
 	}
 
 }

--- a/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetOrderResponseV2.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/dto/response/BouquetOrderResponseV2.java
@@ -1,0 +1,12 @@
+package com.whoa.whoaserver.bouquet.dto.response;
+
+import java.util.List;
+
+public record BouquetOrderResponseV2(
+	Long bouquetId,
+	String bouquetName,
+	String createdAt,
+	List<String> imgPaths,
+	String bouquetStatus
+) {
+}

--- a/src/main/java/com/whoa/whoaserver/bouquet/service/BouquetCustomizingServiceV2.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/service/BouquetCustomizingServiceV2.java
@@ -5,7 +5,7 @@ import com.whoa.whoaserver.bouquet.domain.BouquetImage;
 import com.whoa.whoaserver.bouquet.domain.type.BouquetStatus;
 import com.whoa.whoaserver.bouquet.dto.request.BouquetCustomizingRequest;
 import com.whoa.whoaserver.bouquet.dto.response.BouquetCustomizingResponseV2;
-import com.whoa.whoaserver.bouquet.dto.response.BouquetOrderResponse;
+import com.whoa.whoaserver.bouquet.dto.response.BouquetOrderResponseV2;
 import com.whoa.whoaserver.bouquet.repository.BouquetImageRepository;
 import com.whoa.whoaserver.bouquet.repository.BouquetRepository;
 import com.whoa.whoaserver.flower.domain.FlowerImage;
@@ -133,26 +133,19 @@ public class BouquetCustomizingServiceV2 {
 		bouquetRepository.save(bouquetToUpdate);
 	}
 
-	public Map<String, List<BouquetOrderResponse>> getAllBouquetsByBouquetStatus(Long memberId) {
-		Map<String, List<BouquetOrderResponse>> totalResponse = new HashMap<>();
+	public List<BouquetOrderResponseV2> getAllBouquetsWithStatus(Long memberId) {
+		List<Bouquet> memberBouquets = bouquetRepository.findAllByMemberId(memberId);
 
-		putBouquetOrderResponseListByBouquetStatus(memberId, BouquetStatus.INCOMPLETED, totalResponse);
-		putBouquetOrderResponseListByBouquetStatus(memberId, BouquetStatus.COMPLETED, totalResponse);
-
-		return totalResponse;
-	}
-
-	private void putBouquetOrderResponseListByBouquetStatus(Long memberId, BouquetStatus bouquetStatus, Map<String, List<BouquetOrderResponse>> totalResponse) {
-		List<Bouquet> allBouquetsByStatus = bouquetRepository.findAllByMemberIdAndBouquetStatus(memberId, bouquetStatus);
-		List<BouquetOrderResponse> bouquetResponsesByStatus = allBouquetsByStatus.stream()
-			.map(bouquet -> new BouquetOrderResponse(
-				bouquet.getId(),
-				bouquet.getBouquetName(),
-				bouquet.getCreatedAt().toString().substring(0, 10),
-				getAllSelectedFlowerFromBouquet(bouquet))
-			).collect(Collectors.toUnmodifiableList());
-
-		totalResponse.put(bouquetStatus.getValue(), bouquetResponsesByStatus);
+		return memberBouquets.stream()
+			.map(bouquet -> new BouquetOrderResponseV2(
+					bouquet.getId(),
+					bouquet.getBouquetName(),
+					bouquet.getCreatedAt().toString().substring(0, 10),
+					getAllSelectedFlowerFromBouquet(bouquet),
+					bouquet.getBouquetStatus().getValue()
+				)
+			)
+			.collect(Collectors.toUnmodifiableList());
 	}
 
 	private List<String> getAllSelectedFlowerFromBouquet(Bouquet eachBouquet) {


### PR DESCRIPTION
## 📒 개요
마이페이지 전체/저장된 요구서 조회/제작 완료 항목에서 bouquet 전체 조회 API response dto에 상태가 같은 것끼리 묶어 반환하는 로직으로 구현했으나 프론트에서 편하게 필터링 가능하도록 1차 MVP response dto를 유지하되 status 반환만 추가하도록 수정

## 📍 Issue 번호
close #134 


