### PR TITLE
[Feat] 키워드별 꽃 조회 시 색깔 별로 꽃에 대한 키워드 반환 추가

### DIFF
--- a/src/main/java/com/whoa/whoaserver/keyword/dto/response/FlowerInfoByKeywordResponseV2.java
+++ b/src/main/java/com/whoa/whoaserver/keyword/dto/response/FlowerInfoByKeywordResponseV2.java
@@ -1,19 +1,27 @@
 package com.whoa.whoaserver.keyword.dto.response;
 
 import com.whoa.whoaserver.flowerExpression.domain.FlowerExpression;
+import com.whoa.whoaserver.keyword.domain.Keyword;
+import com.whoa.whoaserver.mapping.domain.FlowerExpressionKeyword;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 public record FlowerInfoByKeywordResponseV2(
 	Long id,
 	String flowerName,
 	String flowerLanguage,
-	String flowerImageUrl
+	String flowerImageUrl,
+	List<String> keywords
 ) {
 	public static FlowerInfoByKeywordResponseV2 from(FlowerExpression flowerExpression) {
 		return new FlowerInfoByKeywordResponseV2(
 			flowerExpression.getFlowerExpressionId(),
 			flowerExpression.getFlower().getFlowerName(),
 			flowerExpression.getFlowerLanguage(),
-			flowerExpression.getFlowerImage().getImageUrl()
+			flowerExpression.getFlowerImage().getImageUrl(),
+			flowerExpression.getFlowerExpressionKeywords().stream()
+				.map(FlowerExpressionKeyword::getKeyword).map(Keyword::getKeywordName).collect(Collectors.toUnmodifiableList())
 		);
 	}
 }


### PR DESCRIPTION
## 📍 Issue 번호
closed #145 

## 🛠️ 작업사항
- [x] 프론트에서 키워드별 꽃 조회 API 연결 이후 선택한 꽃에 대한 keyword list를 저장하여 최종 요구서 저장 직전에 ui/ux 상에서 띄워줌


## ❓ 추가 고려사항

