### PR TITLE
refact: bouquet + image 통합 등록 및 수정 시 이미지 null 허용

### DIFF
--- a/src/main/java/com/whoa/whoaserver/bouquet/controller/BouquetCustomizingControllerV2.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/controller/BouquetCustomizingControllerV2.java
@@ -21,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -41,12 +42,17 @@ public class BouquetCustomizingControllerV2 {
 	public ResponseEntity<BouquetCustomizingResponseV2> registerBouquet(
 		@DeviceUser UserContext userContext,
 		@Valid @RequestPart("request") String bouquetRequest,
-		@RequestPart("imgUrl") List<MultipartFile> multipartFiles
+		@RequestPart(value = "imgUrl", required = false) List<MultipartFile> multipartFiles
 	) {
 
 		try {
 			Long memberId = userContext.id();
 			BouquetCustomizingRequest request = objectMapper.readValue(bouquetRequest, BouquetCustomizingRequest.class);
+
+			if (multipartFiles == null) {
+				multipartFiles = Collections.emptyList();
+			}
+
 			BouquetCustomizingResponseV2 response = bouquetCustomizingServiceV2.registerBouquet(request, memberId, multipartFiles);
 			return ResponseEntity.ok(response);
 		} catch (JsonProcessingException e) {
@@ -62,13 +68,18 @@ public class BouquetCustomizingControllerV2 {
 	public ResponseEntity<BouquetCustomizingResponseV2> updateBouquet(
 		@DeviceUser UserContext userContext,
 		@Valid @RequestPart("request") String bouquetRequest,
-		@RequestPart("imgUrl") List<MultipartFile> multipartFiles,
+		@RequestPart(value = "imgUrl", required = false) List<MultipartFile> multipartFiles,
 		@PathVariable("bouquetId") final Long bouquetId
 	) {
 
 		try {
 			Long memberId = userContext.id();
 			BouquetCustomizingRequest request = objectMapper.readValue(bouquetRequest, BouquetCustomizingRequest.class);
+
+			if (multipartFiles == null) {
+				multipartFiles = Collections.emptyList();
+			}
+
 			BouquetCustomizingResponseV2 response = bouquetCustomizingServiceV2.updateBouquet(request, memberId, bouquetId, multipartFiles);
 			return ResponseEntity.ok(response);
 		} catch (JsonProcessingException e) {

--- a/src/main/java/com/whoa/whoaserver/bouquet/service/BouquetCustomizingServiceV2.java
+++ b/src/main/java/com/whoa/whoaserver/bouquet/service/BouquetCustomizingServiceV2.java
@@ -52,7 +52,13 @@ public class BouquetCustomizingServiceV2 {
 
 		bouquetRepository.save(newBouquet);
 
-		List<String> imgPaths = handleMultipartFiles(memberId, newBouquet, multipartFiles);
+		List<String> imgPaths;
+		if (!multipartFiles.isEmpty()) {
+			imgPaths = handleMultipartFiles(memberId, newBouquet, multipartFiles);
+		} else {
+			imgPaths = Collections.emptyList();
+			;
+		}
 
 		return BouquetCustomizingResponseV2.of(newBouquet, imgPaths);
 	}
@@ -116,7 +122,12 @@ public class BouquetCustomizingServiceV2 {
 		List<BouquetImage> existingBouquetImages = bouquetImageRepository.findAllByBouquet(existingBouquet);
 		bouquetImageRepository.deleteAll(existingBouquetImages);
 
-		List<String> imgPaths = handleMultipartFiles(memberId, existingBouquet, multipartFiles);
+		List<String> imgPaths;
+		if (!multipartFiles.isEmpty()) {
+			imgPaths = handleMultipartFiles(memberId, existingBouquet, multipartFiles);
+		} else {
+			imgPaths = Collections.emptyList();
+		}
 
 		return BouquetCustomizingResponseV2.of(existingBouquet, imgPaths);
 	}


### PR DESCRIPTION
## 📍 Issue 번호
#157 

## 🛠️ 작업사항
- [x] 기존 bouquet + image 통합 업로드, 통합 수정 api에서 모두 multipart를 반드시 받았으나 null 허용



