### PR TITLE
[Fix] 키워드별 꽃 조회(키워드, 구매목적, 선택한 색상 고려) 시 선택한 색상에 따른 예외 처리 강화

### DIFF
--- a/src/main/java/com/whoa/whoaserver/domain/flowerExpression/repository/FlowerExpressionRepository.java
+++ b/src/main/java/com/whoa/whoaserver/domain/flowerExpression/repository/FlowerExpressionRepository.java
@@ -3,6 +3,7 @@ package com.whoa.whoaserver.domain.flowerExpression.repository;
 import com.whoa.whoaserver.domain.flowerExpression.domain.FlowerExpression;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -13,4 +14,7 @@ public interface FlowerExpressionRepository extends JpaRepository<FlowerExpressi
 	FlowerExpression findByFlowerExpressionId(Long flowerExpressionid);
 
 	List<FlowerExpression> findByFlowerFlowerId(Long flowerId);
+
+	@Query("SELECT DISTINCT f.flowerColor FROM FlowerExpression f")
+	List<String> findDistinctFlowerColors();
 }

--- a/src/main/java/com/whoa/whoaserver/domain/keyword/service/FlowerKeywordServiceV3.java
+++ b/src/main/java/com/whoa/whoaserver/domain/keyword/service/FlowerKeywordServiceV3.java
@@ -1,16 +1,19 @@
 package com.whoa.whoaserver.domain.keyword.service;
 
 import com.whoa.whoaserver.domain.flowerExpression.domain.FlowerExpression;
+import com.whoa.whoaserver.domain.flowerExpression.repository.FlowerExpressionRepository;
 import com.whoa.whoaserver.domain.keyword.dto.response.FlowerInfoByKeywordResponseV2;
 import com.whoa.whoaserver.domain.mapping.domain.CustomizingPurposeKeyword;
 import com.whoa.whoaserver.domain.mapping.domain.FlowerExpressionKeyword;
 import com.whoa.whoaserver.domain.mapping.repository.CustomizingPurposeKeywordRepository;
+import com.whoa.whoaserver.global.exception.ExceptionCode;
 import com.whoa.whoaserver.global.exception.WhoaException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.whoa.whoaserver.global.exception.ExceptionCode.INVALID_MATCHING_WITH_CUSTOMIZING_PURPOSE_AND_KEYWORD;
 
@@ -21,32 +24,60 @@ public class FlowerKeywordServiceV3 {
 	private static final int TOTAL_FLOWER_INFORMATION_FLAG_BY_KEYWORD_ID = 0;
 
 	private final CustomizingPurposeKeywordRepository customizingPurposeKeywordRepository;
+	private final FlowerExpressionRepository flowerExpressionRepository;
 	private final FlowerKeywordService flowerKeywordService;
+	private final FlowerKeywordServiceV2 flowerKeywordServiceV2;
 
 	@Transactional(readOnly = true)
 	public List<FlowerInfoByKeywordResponseV2> getFlowerInfoByKeywordAndCustomizingPurposeAndColor(Long customizingPurposeId, Long keywordId, List<String> selectedColors) {
-		List<CustomizingPurposeKeyword> customizingPurposeKeywordList;
-
-		if (keywordId == TOTAL_FLOWER_INFORMATION_FLAG_BY_KEYWORD_ID) {
-			customizingPurposeKeywordList = customizingPurposeKeywordRepository.findAllByCustomizingPurpose_CustomizingPurposeId(customizingPurposeId);
+		if (selectedColors == null || selectedColors.isEmpty()) {
+			return flowerKeywordServiceV2.getFlowerInfoByKeywordAndCustomizingPurpose(customizingPurposeId, keywordId);
 		} else {
-			customizingPurposeKeywordList = customizingPurposeKeywordRepository.findAllByCustomizingPurpose_CustomizingPurposeIdAndKeyword_KeywordId(customizingPurposeId, keywordId);
+			List<String> flowerColors = flowerExpressionRepository.findDistinctFlowerColors().stream()
+				.map(String::toLowerCase)
+				.toList();
 
-			if (customizingPurposeKeywordList.isEmpty()) {
-				throw new WhoaException(INVALID_MATCHING_WITH_CUSTOMIZING_PURPOSE_AND_KEYWORD);
+			List<String> selectedColorsForCaseInsensitiveComparsion = selectedColors.stream()
+				.map(String::toLowerCase)
+				.toList();
+
+			Boolean isContained = false;
+			for (String selectBouquetColor : selectedColorsForCaseInsensitiveComparsion) {
+				if (flowerColors.contains(selectBouquetColor)) {
+					isContained = true;
+					break;
+				}
 			}
+
+			if (!isContained) throw new WhoaException(ExceptionCode.INVALID_MATCHING_WITH_BOUQUET_SELECTED_COLORS_AND_FLOWEREXPRESSION_FLOWER_COLORS);
+
+			List<CustomizingPurposeKeyword> customizingPurposeKeywordList;
+
+			if (keywordId == TOTAL_FLOWER_INFORMATION_FLAG_BY_KEYWORD_ID) {
+				customizingPurposeKeywordList = customizingPurposeKeywordRepository.findAllByCustomizingPurpose_CustomizingPurposeId(customizingPurposeId);
+			} else {
+				customizingPurposeKeywordList = customizingPurposeKeywordRepository.findAllByCustomizingPurpose_CustomizingPurposeIdAndKeyword_KeywordId(customizingPurposeId, keywordId);
+
+				if (customizingPurposeKeywordList.isEmpty()) {
+					throw new WhoaException(INVALID_MATCHING_WITH_CUSTOMIZING_PURPOSE_AND_KEYWORD);
+				}
+			}
+
+			List<FlowerExpression> targetFlowerExpressionByCustomizingPurpose = customizingPurposeKeywordList.stream()
+				.map(CustomizingPurposeKeyword::getKeyword)
+				.flatMap(keyword -> keyword.getFlowerExpressionKeywords().stream())
+				.map(FlowerExpressionKeyword::getFlowerExpression)
+				.filter(flowerKeywordService::isInContemplationPeriod)
+				.filter(flowerExpression -> selectedColorsForCaseInsensitiveComparsion.contains(flowerExpression.getFlowerColor().toLowerCase()))
+				.toList();
+
+			if (targetFlowerExpressionByCustomizingPurpose.isEmpty()) {
+				throw new WhoaException(ExceptionCode.INVALID_MATCHING_WITH_BOUQUET_SELECTED_COLORS_AND_FLOWER_COLORS_AND_KEYWORD_AND_CUSTOMIZING_PURPOSE);
+			}
+
+			return targetFlowerExpressionByCustomizingPurpose.stream()
+				.map(FlowerInfoByKeywordResponseV2::from)
+				.toList();
 		}
-
-		List<FlowerExpression> targetFlowerExpressionByCustomizingPurpose = customizingPurposeKeywordList.stream()
-			.map(CustomizingPurposeKeyword::getKeyword)
-			.flatMap(keyword -> keyword.getFlowerExpressionKeywords().stream())
-			.map(FlowerExpressionKeyword::getFlowerExpression)
-			.filter(flowerKeywordService::isInContemplationPeriod)
-			.filter(flowerExpression -> selectedColors.contains(flowerExpression.getFlowerColor()))
-			.toList();
-
-		return targetFlowerExpressionByCustomizingPurpose.stream()
-			.map(FlowerInfoByKeywordResponseV2::from)
-			.toList();
 	}
 }

--- a/src/main/java/com/whoa/whoaserver/global/exception/ExceptionCode.java
+++ b/src/main/java/com/whoa/whoaserver/global/exception/ExceptionCode.java
@@ -20,6 +20,8 @@ public enum ExceptionCode {
 	DUPLICATED_BOUQUET_NAME(HttpStatus.CONFLICT, "해당 유저가 이미 동일한 꽃다발 주문서 이름으로 등록한 이력이 있습니다."),
 
 	INVALID_MATCHING_WITH_CUSTOMIZING_PURPOSE_AND_KEYWORD(HttpStatus.NOT_FOUND, "구매 목적에 대응되는 꽃말의 키워드가 업습니다."),
+	INVALID_MATCHING_WITH_BOUQUET_SELECTED_COLORS_AND_FLOWEREXPRESSION_FLOWER_COLORS(HttpStatus.NOT_FOUND, "원하는 꽃다발 색상에 부합하는 색깔을 가진 꽃이 데이터베이스에 없습니다."),
+	INVALID_MATCHING_WITH_BOUQUET_SELECTED_COLORS_AND_FLOWER_COLORS_AND_KEYWORD_AND_CUSTOMIZING_PURPOSE(HttpStatus.NOT_FOUND, "구매 목적에 부합하는 키워드를 flowerLanguage로 가진 flowerExpression은 있으나 원하는 꽃다발 색상에 부합하지 않습니다."),
 
 	DUPLICATED_FILE_NAME(HttpStatus.CONFLICT, "이미 존재하는 파일 이름입니다."),
 	IMAGE_SIZE_LIMIT_ERROR(HttpStatus.FORBIDDEN, "이미지의 크기가 기준을 초과합니다."),


### PR DESCRIPTION
## 📒 개요
requestParam List<String> selectedColors에 대한 예외 처리 추가하여 500 에러 방지

## 📍 Issue 번호
closed #179

## 🛠️ 작업사항
- [x] selectedColors가 flowerExpression table의 flower_color에 아얘 부합하지 않는 경우 예외 처리 추가 (선택된 꽃이 db에 저장된 모든 꽃말-색깔 data에 없을 경우)
- [x] 구매 목적과 키워드에 부합하는 flowerExpression은 있으나 selectedColor(선택된 색상)을 가진 flowerExpression이 없을 경우 예외 처리 추가


## ❓ 추가 고려사항
2차 mvp 코드와 중복인 부분 리펙토링 필요
