### PR TITLE
[Feat] 인기 꽃 순위 조회에서 주간 순위 변동 추가

### DIFF
--- a/src/main/java/com/whoa/whoaserver/domain/flower/domain/FlowerPopularity.java
+++ b/src/main/java/com/whoa/whoaserver/domain/flower/domain/FlowerPopularity.java
@@ -28,32 +28,38 @@ public class FlowerPopularity {
 
 	String flowerLanguage;
 
+	@Column(nullable = false)
+	Integer rankDifference;
+
 	@Builder(access = AccessLevel.PRIVATE)
-	public FlowerPopularity(Long flowerId, String flowerImageUrl, Integer flowerRanking, String flowerName, String flowerLanguage) {
+	public FlowerPopularity(Long flowerId, String flowerImageUrl, Integer flowerRanking, String flowerName, String flowerLanguage, Integer rankDifference) {
 		this.flowerId = flowerId;
 		this.flowerImageUrl = flowerImageUrl;
 		this.flowerRanking = flowerRanking;
 		this.flowerName = flowerName;
 		this.flowerLanguage = flowerLanguage;
+		this.rankDifference = rankDifference;
 	}
 
 	public static FlowerPopularity initializeFlowerPopularityRanking(Long flowerId, String flowerImageUrl, Integer flowerRanking,
-																	 String flowerName, String flowerLanguage) {
+																	 String flowerName, String flowerLanguage, Integer rankDifference) {
 		return FlowerPopularity.builder()
 			.flowerId(flowerId)
 			.flowerImageUrl(flowerImageUrl)
 			.flowerRanking(flowerRanking)
 			.flowerName(flowerName)
 			.flowerLanguage(flowerLanguage)
+			.rankDifference(rankDifference)
 			.build();
 	}
 
 	public void updateFlowerPopularity(Long flowerId, String flowerImageUrl, Integer flowerRanking,
-									   String flowerName, String flowerLanguage) {
+									   String flowerName, String flowerLanguage, Integer rankDifference) {
 		this.flowerId = flowerId;
 		this.flowerImageUrl = flowerImageUrl;
 		this.flowerRanking = flowerRanking;
 		this.flowerName = flowerName;
 		this.flowerLanguage = flowerLanguage;
+		this.rankDifference = rankDifference;
 	}
 }

--- a/src/main/java/com/whoa/whoaserver/domain/flower/dto/response/FlowerPopularityResponseDto.java
+++ b/src/main/java/com/whoa/whoaserver/domain/flower/dto/response/FlowerPopularityResponseDto.java
@@ -10,13 +10,16 @@ public class FlowerPopularityResponseDto {
 	Integer flowerRanking;
 	String flowerName;
 	String flowerLanguage;
+	Integer rankDifference;
 
 	@QueryProjection
-	public FlowerPopularityResponseDto(Long flowerId, String flowerImageUrl, Integer flowerRanking, String flowerName, String flowerLanguage) {
+	public FlowerPopularityResponseDto(Long flowerId, String flowerImageUrl, Integer flowerRanking,
+									   String flowerName, String flowerLanguage, Integer rankDifference) {
 		this.flowerId = flowerId;
 		this.flowerImageUrl = flowerImageUrl;
 		this.flowerRanking = flowerRanking;
 		this.flowerName = flowerName;
 		this.flowerLanguage = flowerLanguage;
+		this.rankDifference = rankDifference;
 	}
 }

--- a/src/main/java/com/whoa/whoaserver/domain/flower/repository/ranking/FlowerPopularityRepository.java
+++ b/src/main/java/com/whoa/whoaserver/domain/flower/repository/ranking/FlowerPopularityRepository.java
@@ -4,6 +4,5 @@ import com.whoa.whoaserver.domain.flower.domain.FlowerPopularity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FlowerPopularityRepository extends JpaRepository<FlowerPopularity, Long>, FlowerPopularityRepositoryCustom {
-
-	FlowerPopularity findByFlowerRanking(Integer flowerRanking);
+	FlowerPopularity findByFlowerId(Long flowerId);
 }

--- a/src/main/java/com/whoa/whoaserver/domain/flower/repository/ranking/FlowerPopularityRepositoryCustom.java
+++ b/src/main/java/com/whoa/whoaserver/domain/flower/repository/ranking/FlowerPopularityRepositoryCustom.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface FlowerPopularityRepositoryCustom {
 
-	List<FlowerPopularityResponseDto> findAllFlowerPopularityRanking();
+	List<FlowerPopularityResponseDto> findTop5FlowerPopularityRanking();
 }

--- a/src/main/java/com/whoa/whoaserver/domain/flower/repository/ranking/FlowerPopularityRepositoryImpl.java
+++ b/src/main/java/com/whoa/whoaserver/domain/flower/repository/ranking/FlowerPopularityRepositoryImpl.java
@@ -15,16 +15,19 @@ public class FlowerPopularityRepositoryImpl implements FlowerPopularityRepositor
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public List<FlowerPopularityResponseDto> findAllFlowerPopularityRanking() {
+	public List<FlowerPopularityResponseDto> findTop5FlowerPopularityRanking() {
 		return jpaQueryFactory
 			.select(Projections.constructor(FlowerPopularityResponseDto.class,
 				flowerPopularity.flowerId,
 				flowerPopularity.flowerImageUrl,
 				flowerPopularity.flowerRanking,
 				flowerPopularity.flowerName,
-				flowerPopularity.flowerLanguage
+				flowerPopularity.flowerLanguage,
+				flowerPopularity.rankDifference
 				))
 			.from(flowerPopularity)
+			.orderBy(flowerPopularity.flowerRanking.asc())
+			.limit(5)
 			.fetch();
 	}
 }

--- a/src/main/java/com/whoa/whoaserver/domain/flower/service/FlowerRankingServiceV3.java
+++ b/src/main/java/com/whoa/whoaserver/domain/flower/service/FlowerRankingServiceV3.java
@@ -14,6 +14,6 @@ public class FlowerRankingServiceV3 {
 	private final FlowerPopularityRepository flowerPopularityRepository;
 
 	public List<FlowerPopularityResponseDto> getFlowerPopularityRanking() {
-		return flowerPopularityRepository.findAllFlowerPopularityRanking();
+		return flowerPopularityRepository.findTop5FlowerPopularityRanking();
 	}
 }

--- a/src/main/java/com/whoa/whoaserver/scheduler/FlowerPopularityScheduler.java
+++ b/src/main/java/com/whoa/whoaserver/scheduler/FlowerPopularityScheduler.java
@@ -51,31 +51,33 @@ public class FlowerPopularityScheduler {
 		int flowerRanking = 1;
 		if (flowerPopularityRepository.count() == 0L) {
 			for(Flower popularFlower : keySetFlowerExpressionIdList) {
-				if (flowerRanking > 5) break;
 				FlowerPopularity newFlowerPopularity = FlowerPopularity.initializeFlowerPopularityRanking(
 					popularFlower.getFlowerId(),
 					getFlowerImageUrlByFlower(popularFlower),
 					flowerRanking,
 					popularFlower.getFlowerName(),
-					getFlowerExpressionByFlower(popularFlower)
+					getFlowerExpressionByFlower(popularFlower),
+					0
 				);
 				flowerPopularityRepository.save(newFlowerPopularity);
 				flowerRanking++;
 			}
 		} else {
+			ArrayList<FlowerPopularity> flowerPopularityList = new ArrayList<>();
 			for(Flower popularFlower : keySetFlowerExpressionIdList) {
-				if (flowerRanking > 5) break;
-				FlowerPopularity existingFlowerPopularity = flowerPopularityRepository.findByFlowerRanking(flowerRanking);
+				FlowerPopularity existingFlowerPopularity = flowerPopularityRepository.findByFlowerId(popularFlower.getFlowerId());
 				existingFlowerPopularity.updateFlowerPopularity(
 					popularFlower.getFlowerId(),
 					getFlowerImageUrlByFlower(popularFlower),
 					flowerRanking,
 					popularFlower.getFlowerName(),
-					getFlowerExpressionByFlower(popularFlower)
+					getFlowerExpressionByFlower(popularFlower),
+					flowerRanking - existingFlowerPopularity.getRankDifference()
 				);
-				flowerPopularityRepository.save(existingFlowerPopularity);
+				flowerPopularityList.add(existingFlowerPopularity);
 				flowerRanking++;
 			}
+			flowerPopularityRepository.saveAll(flowerPopularityList);
 		}
 
 	}
@@ -86,11 +88,11 @@ public class FlowerPopularityScheduler {
 	}
 
 	private String getFlowerImageUrlByFlower(Flower flower) {
-		return (flower.getFlowerImages() == null)? "" : flower.getFlowerImages().get(0).getImageUrl();
+		return (flower.getFlowerImages() == null || flower.getFlowerImages().isEmpty()) ? "" : flower.getFlowerImages().get(0).getImageUrl();
 	}
 
 	private String getFlowerExpressionByFlower(Flower flower) {
-		return (flower.getFlowerExpressions() == null)? "" : flower.getFlowerExpressions().get(0).getFlowerLanguage();
+		return (flower.getFlowerExpressions() == null || (flower.getFlowerExpressions().isEmpty()))? "" : flower.getFlowerExpressions().get(0).getFlowerLanguage();
 	}
 
 }


### PR DESCRIPTION
## 📒 개요
- 4차 MVP 
- 인기 꽃 순위 조회에서 순위 변동 추가에 따른 전반적인 로직 수정

## 📍 Issue 번호
closed #199 
closed #202

## 🛠️ 작업사항
- [x] 인기 꽃 랭킹 스케쥴러에서 지난주와 비교한 rankDifference 순위 변동 갱신 추가
- [x] 인기 꽃 순위 조회 api에서 top5, orderBy 추가
- [x] 상위 5개만 flowerPopularity에 저장하던 로직에서 전체 순위 저장으로 바뀌면서 고려해야 하는 예외 처리 해결 


## ❓ 추가 고려사항

